### PR TITLE
Fix comments export to ParaText 7 and/or 8

### DIFF
--- a/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
+++ b/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
@@ -82,7 +82,7 @@ class ParatextExport
         $user = new UserModel((string) $comment['userRef']);
         $username = $user->username;
 
-        $content = self::sanitizeComment($comment['content']) . " (by " . $user->username . " on " . $comment['dateEdited']->toDateTime()->format(\DateTime::RFC822) . ")";
+        $content = self::sanitizeComment($comment['content']) . " (by " . $user->username . ")";
         if (count($tags) > 0) {
             $content .= " (Tags: ";
             foreach ($tags as $tag) {
@@ -98,10 +98,10 @@ class ParatextExport
         return "\t<Comment>
         <Thread>" . $commentId . "</Thread>
         <User>SF-$username</User>
-        <Date>" . $comment['dateEdited']->toDateTime()->format(\DateTime::RFC822) . "</Date>
+        <Date>" . $comment['dateEdited']->toDateTime()->format(\DateTime::ATOM) . "</Date>
         <VerseRef>" . $textInfo['bookCode'] . " " . $textInfo['startChapter'] . ":" . $textInfo['startVerse'] . "</VerseRef>
         <SelectedText />
-        <StartPosition>" . $textInfo['startVerse'] . "</StartPosition>
+        <StartPosition>0</StartPosition>
         <ContextBefore>\\v " . $textInfo['startVerse'] . "</ContextBefore>
         <ContextAfter/>
         <Status>todo</Status>

--- a/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
+++ b/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
@@ -35,7 +35,7 @@ class ParatextExport
                         $dl['xml'] .= self::makeCommentXml($answer['tags'], $answer['score'], $textInfo, $answerId, $answer);
                         if ($params['exportComments']) {
                             foreach ($answer['comments'] as $commentId => $comment) {
-                                $dl['xml'] .= self::makeCommentXml(array(), 0, $textInfo, $commentId, $comment);
+                                $dl['xml'] .= self::makeCommentXml(array(), 0, $textInfo, $answerId, $comment); // answerId, not commentId, so that Paratext will thread them together
                                 $dl['commentCount']++;
                             }
                         }
@@ -74,10 +74,10 @@ class ParatextExport
      * @param array $tags
      * @param int $votes
      * @param array $textInfo
-     * @param string $commentId
+     * @param string $threadId
      * @param array $comment
      */
-    private static function makeCommentXml($tags, $votes, $textInfo, $commentId, $comment)
+    private static function makeCommentXml($tags, $votes, $textInfo, $threadId, $comment)
     {
         $user = new UserModel((string) $comment['userRef']);
         $username = $user->username;
@@ -96,7 +96,7 @@ class ParatextExport
         }
 
         return "\t<Comment>
-        <Thread>" . $commentId . "</Thread>
+        <Thread>" . $threadId . "</Thread>
         <User>SF-$username</User>
         <Date>" . $comment['dateEdited']->toDateTime()->format(\DateTime::ATOM) . "</Date>
         <VerseRef>" . $textInfo['bookCode'] . " " . $textInfo['startChapter'] . ":" . $textInfo['startVerse'] . "</VerseRef>

--- a/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
+++ b/src/Api/Library/Scriptureforge/Sfchecks/ParatextExport.php
@@ -44,9 +44,9 @@ class ParatextExport
             }
         }
 
-        $dateForFilename = date('Ymd_Gi');
-        $dateTimeForFilename = \DateTime::createFromFormat('Ymd_Gi', $dateForFilename);
-        $dl['xml'] .= self::makeDummyComment($commentFormatter, $dateTimeForFilename, $dateForFilename);
+        $now = new \DateTime();
+        $dateForFilename = date('Ymd_Gi', $now->getTimestamp());
+        $dl['xml'] .= self::makeDummyComment($commentFormatter, $now, $dateForFilename);
 
         foreach ($questionlist->entries as $question) {
             if (! array_key_exists('isArchived', $question) || ! $question['isArchived']) {

--- a/src/Api/Model/Scriptureforge/Sfchecks/Dto/UsxTrimHelper.php
+++ b/src/Api/Model/Scriptureforge/Sfchecks/Dto/UsxTrimHelper.php
@@ -11,6 +11,7 @@ class UsxTrimHelper
 
     // States
     private $_stateDrop;
+    private $_currentBook;
     private $_currentChapter;
     private $_currentVerse;
 
@@ -66,6 +67,7 @@ class UsxTrimHelper
         array_push($this->_tagStack, $attrs);
         switch ($tag) {
             case 'USX':
+            case 'BOOK':
                 $this->outputStartTag($tag, $attrs);
                 array_pop($this->_tagStack); // Do not leave <usx> tag on stack
                 array_pop($this->_tagStack);
@@ -91,8 +93,8 @@ class UsxTrimHelper
     {
         switch ($tag) {
             case 'USX':
-                $this->outputEndTag('usx');
-
+            case 'BOOK':
+                $this->outputEndTag($tag);
                 return;
             case 'VERSE':
                 break;
@@ -227,6 +229,14 @@ class UsxTrimHelper
         }
 
                 // Boundary chapter; need to check verses
+    }
+
+    private function onBook($attrs)
+    {
+        // Always echo book start
+        $number = (int) $attrs['NUMBER'];
+        $this->_currentVerse = (int) $number;
+        $this->setDropStateByVerse();
     }
 
     private function onChapter($attrs)

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
@@ -137,10 +137,10 @@
                     <div>
                         <button class="btn btn-primary" data-ng-disabled="exportForm.$invalid || download.inprogress"
                                 data-ng-click="startExport('PT7')">
-                            Format for Paratext 7</button>
+                            Download for Paratext 7</button>
                         <button class="btn btn-primary" data-ng-disabled="exportForm.$invalid || download.inprogress"
                                 data-ng-click="startExport('PT8')">
-                            Format for Paratext 8</button>
+                            Download for Paratext 8</button>
                     <span data-ng-show="download.inprogress">
                             <i class="fa fa-spinner fa-spin" style="position: absolute; padding-left: 5px; padding-top: 8px;"></i></span>
                     </div>
@@ -152,18 +152,6 @@
                             answers/comments</p>
                     </div>
                 </form>
-                <div class="col-sm-6" data-ng-show="download.totalCount">
-                    <br class="d-sm-none">
-                    <p data-ng-show="download.totalCount > 0" class="text-success">
-                        Ready to Download: <span data-ng-show="download.answerCount > 0"
-                                                 class="label label-success"><span class="notranslate">{{download.answerCount}}</span>
-                    answer(s)</span> <span data-ng-show="download.commentCount > 0"
-                                           class="label label-info"><span class="notranslate">{{download.commentCount}}</span>
-                    comment(s)</span>
-                    </p>
-                    <button data-ng-click="downloadExport()" class="btn btn-primary">
-                        Download ParaTExt XML File</button>
-                </div>
             </div>
         </uib-tab>
     </uib-tabset>

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions-settings.html
@@ -136,9 +136,12 @@
                     </div>
                     <div>
                         <button class="btn btn-primary" data-ng-disabled="exportForm.$invalid || download.inprogress"
-                                data-ng-click="startExport()">
-                            Prepare Export</button>
-                        <span data-ng-show="download.inprogress">
+                                data-ng-click="startExport('PT7')">
+                            Format for Paratext 7</button>
+                        <button class="btn btn-primary" data-ng-disabled="exportForm.$invalid || download.inprogress"
+                                data-ng-click="startExport('PT8')">
+                            Format for Paratext 8</button>
+                    <span data-ng-show="download.inprogress">
                             <i class="fa fa-spinner fa-spin" style="position: absolute; padding-left: 5px; padding-top: 8px;"></i></span>
                     </div>
                     <div class="form-group">

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions.js
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions.js
@@ -510,20 +510,19 @@ angular.module('sfchecks.questions', ['ui.bootstrap', 'coreModule', 'sgw.ui.brea
         if (result.ok) {
           $scope.download = result.data;
           $scope.download.complete = true;
+          if ($scope.download.totalCount > 0) {
+            // for a reference on how to create a data-uri for use in downloading content see
+            // http://stackoverflow.com/questions/16514509/how-do-you-serve-a-file-for-download-with-angularjs-or-javascript
+            var uri = 'data:text/plain;charset=utf-8,' + encodeURIComponent($scope.download.xml);
+            var link = document.createElement('a');
+            link.download = $scope.download.filename;
+            link.href = uri;
+            link.click();
+          }
         }
 
         $scope.download.inprogress = false;
       });
-    };
-
-    $scope.downloadExport = function () {
-      // for a reference on how to create a data-uri for use in downloading content see
-      // http://stackoverflow.com/questions/16514509/how-do-you-serve-a-file-for-download-with-angularjs-or-javascript
-      var uri = 'data:text/plain;charset=utf-8,' + encodeURIComponent($scope.download.xml);
-      var link = document.createElement('a');
-      link.download = $scope.download.filename;
-      link.href = uri;
-      link.click();
     };
 
   }])

--- a/src/angular-app/scriptureforge/sfchecks/partials/questions.js
+++ b/src/angular-app/scriptureforge/sfchecks/partials/questions.js
@@ -484,6 +484,7 @@ angular.module('sfchecks.questions', ['ui.bootstrap', 'coreModule', 'sgw.ui.brea
   function ($scope, textService, $routeParams) {
     $scope.exportConfig = {
       textId: $routeParams.textId,
+      commentFormat: "PT7",
       exportComments: false,
       exportFlagged: true,
       tags: []
@@ -502,7 +503,8 @@ angular.module('sfchecks.questions', ['ui.bootstrap', 'coreModule', 'sgw.ui.brea
       return true;
     };
 
-    $scope.startExport = function () {
+    $scope.startExport = function (ptVersion = "PT7") {
+      $scope.exportConfig.commentFormat = ptVersion;
       $scope.download.inprogress = true;
       textService.exportComments($scope.exportConfig, function (result) {
         if (result.ok) {


### PR DESCRIPTION
For review; I'll squash down to a single commit before I actually merge this.

This fixes comment exporting for both Paratext 7 and 8. I've changed the "Prepare Export" button to be two buttons, one for Paratext 7 and one for Paratext 8 instead. Screenshot:

![image](https://user-images.githubusercontent.com/90762/35614747-abdeca18-06a2-11e8-8be1-68a6cdbbbc08.png)

One feature NOT included in this PR is the ability to export all comments, not just those in a single text. The code is in place, we just have to implement it and add the UI to the project settings screen. But this branch will at least get the feature working first; then we can add convenience.